### PR TITLE
Fixed a bug where Discovery timeout failed to trigger.

### DIFF
--- a/Open.Nat/NatUtility.cs
+++ b/Open.Nat/NatUtility.cs
@@ -180,7 +180,7 @@ namespace Open.Nat
             var task = Task.Factory.StartNew(SearchAndListen, TaskCreationOptions.LongRunning);
             task.ContinueWith(o =>
                 {
-                    var exceptionType = task.Exception.GetType();
+                    var exceptionType = task.Exception.GetBaseException().GetType();
                     if (exceptionType == typeof(TimeoutException) && DiscoveryTimedout != null)
                     {
                         DiscoveryTimedout(typeof (NatUtility), new DiscoveryTimeoutEventArgs());


### PR DESCRIPTION
The exception being raised for a discovery timeout event wasn't properly checking the base exception type.
