### PR TITLE
Now runs in .Net Core and/or PowerShell

### DIFF
--- a/Open.Nat/Upnp/Messages/Responses/AddPortMappingResponseMessage.cs
+++ b/Open.Nat/Upnp/Messages/Responses/AddPortMappingResponseMessage.cs
@@ -24,9 +24,15 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System.Xml;
+
 namespace Open.Nat
 {
     internal class AddPortMappingResponseMessage : ResponseMessageBase
     {
+		protected AddPortMappingResponseMessage(XmlDocument response, string serviceType, string typeName)
+			: base(response, serviceType, typeName)
+		{
+		}
     }
 }

--- a/Open.Nat/Upnp/Messages/Responses/DeletePortMappingResponseMessage.cs
+++ b/Open.Nat/Upnp/Messages/Responses/DeletePortMappingResponseMessage.cs
@@ -24,9 +24,15 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System.Xml;
+
 namespace Open.Nat
 {
     internal class DeletePortMappingResponseMessage : ResponseMessageBase
     {
+		protected DeletePortMappingResponseMessage(XmlDocument response, string serviceType, string typeName)
+			: base(response, serviceType, typeName)
+		{
+		}
     }
 }


### PR DESCRIPTION
The base class does not have a zero-argument constructor so it has to call the constructor with arguments. 

The only other solution to the one provided here would be to add a zero-argument constructor to the base class. 