### PR TITLE
Add property to get local endpoint of discovered NAT device

### DIFF
--- a/Open.Nat/NatDevice.cs
+++ b/Open.Nat/NatDevice.cs
@@ -42,6 +42,16 @@ namespace Open.Nat
 	/// </summary>
 	public abstract class NatDevice
 	{
+		/// <summary>
+		/// A local endpoint of NAT device.
+		/// </summary>
+		public abstract IPEndPoint HostEndPoint { get; }
+
+		/// <summary>
+		/// A local IP address of client.
+		/// </summary>
+		public abstract IPAddress LocalAddress { get; }
+
 		private readonly HashSet<Mapping> _openedMapping = new HashSet<Mapping>();
 		protected DateTime LastSeen { get; private set; }
 

--- a/Open.Nat/Pmp/PmpNatDevice.cs
+++ b/Open.Nat/Pmp/PmpNatDevice.cs
@@ -37,15 +37,24 @@ namespace Open.Nat
 {
 	internal sealed class PmpNatDevice : NatDevice
 	{
-		public override IPEndPoint HostEndPoint { get; }
-		public override IPAddress LocalAddress { get; }
+		public override IPEndPoint HostEndPoint
+		{
+			get { return _hostEndPoint; }
+		}
 
+		public override IPAddress LocalAddress
+		{
+			get { return _localAddress; }
+		}
+
+		private readonly IPEndPoint _hostEndPoint;
+		private readonly IPAddress _localAddress;
 		private readonly IPAddress _publicAddress;
 
 		internal PmpNatDevice(IPAddress hostEndPointAddress, IPAddress localAddress, IPAddress publicAddress)
 		{
-			HostEndPoint = new IPEndPoint(hostEndPointAddress, PmpConstants.ServerPort);
-			LocalAddress = localAddress;
+			_hostEndPoint = new IPEndPoint(hostEndPointAddress, PmpConstants.ServerPort);
+			_localAddress = localAddress;
 			_publicAddress = publicAddress;
 		}
 

--- a/Open.Nat/Pmp/PmpSearcher.cs
+++ b/Open.Nat/Pmp/PmpSearcher.cs
@@ -139,7 +139,7 @@ namespace Open.Nat
 			//NextSearch = DateTime.Now.AddMinutes(5);
 
 			_timeout = 250;
-			return new PmpNatDevice(endpoint.Address, publicIp);
+			return new PmpNatDevice(localAddress, endpoint.Address, publicIp);
 		}
 	}
 }

--- a/Open.Nat/Upnp/UpnpNatDevice.cs
+++ b/Open.Nat/Upnp/UpnpNatDevice.cs
@@ -38,10 +38,17 @@ namespace Open.Nat
 {
 	internal sealed class UpnpNatDevice : NatDevice
 	{
-		public override IPEndPoint HostEndPoint => DeviceInfo.HostEndPoint;
-		public override IPAddress LocalAddress => DeviceInfo.LocalAddress;
+        public override IPEndPoint HostEndPoint
+        {
+            get { return DeviceInfo.HostEndPoint; }
+        }
 
-		internal readonly UpnpNatDeviceInfo DeviceInfo;
+        public override IPAddress LocalAddress
+        {
+            get { return DeviceInfo.LocalAddress; }
+        }
+
+        internal readonly UpnpNatDeviceInfo DeviceInfo;
 		private readonly SoapClient _soapClient;
 
 		internal UpnpNatDevice(UpnpNatDeviceInfo deviceInfo)

--- a/Open.Nat/Upnp/UpnpNatDevice.cs
+++ b/Open.Nat/Upnp/UpnpNatDevice.cs
@@ -38,17 +38,17 @@ namespace Open.Nat
 {
 	internal sealed class UpnpNatDevice : NatDevice
 	{
-        public override IPEndPoint HostEndPoint
-        {
-            get { return DeviceInfo.HostEndPoint; }
-        }
+		public override IPEndPoint HostEndPoint
+		{
+			get { return DeviceInfo.HostEndPoint; }
+		}
 
-        public override IPAddress LocalAddress
-        {
-            get { return DeviceInfo.LocalAddress; }
-        }
+		public override IPAddress LocalAddress
+		{
+			get { return DeviceInfo.LocalAddress; }
+		}
 
-        internal readonly UpnpNatDeviceInfo DeviceInfo;
+		internal readonly UpnpNatDeviceInfo DeviceInfo;
 		private readonly SoapClient _soapClient;
 
 		internal UpnpNatDevice(UpnpNatDeviceInfo deviceInfo)

--- a/Open.Nat/Upnp/UpnpNatDevice.cs
+++ b/Open.Nat/Upnp/UpnpNatDevice.cs
@@ -38,6 +38,9 @@ namespace Open.Nat
 {
 	internal sealed class UpnpNatDevice : NatDevice
 	{
+		public override IPEndPoint HostEndPoint => DeviceInfo.HostEndPoint;
+		public override IPAddress LocalAddress => DeviceInfo.LocalAddress;
+
 		internal readonly UpnpNatDeviceInfo DeviceInfo;
 		private readonly SoapClient _soapClient;
 


### PR DESCRIPTION
I added properties to get the local endpoint of NAT device and the IP address of the client which connected to the NAT device.
This is related to #37 .

I have added two properties as below to `NatDevice` class and implemented overrides to child classes.

- HostEndPoint: the local endpoint of NAT device
- LocalAddress:  the IP address of the client which connected to the NAT device

## `UpnpNatDevice` class

I used `UpnpNatDeviceInfo`.

- HostEndPoint: UpnpNatDeviceInfo.HostEndPoint
- LocalAddress: UpnpNatDeviceInfo.LocalAddress

## `PmpNatDevice` class

The meaning of `LocalAddress` property in `PmpNatDevice` class was same as the meaning of `HostEndPoint.Address` property in `UpnpNatDeviceInfo` class, so I changed `LocalAddress` property to `HostEndPoint` property and add new `LocalAddress` property.

I set the port of `HostEndPoint` as `PmpConstants.ServerPort` because old `LocalAddress` was used that way in other parts of codes.