### PR TITLE
Added failure code for LINKSYS EA8300

### DIFF
--- a/Open.Nat/Upnp/UpnpConstants.cs
+++ b/Open.Nat/Upnp/UpnpConstants.cs
@@ -30,8 +30,10 @@ namespace Open.Nat
 	{
 		public const int InvalidArguments = 402;
 		public const int ActionFailed = 501;
+		public const int ArgumentValueOutOfRange = 601;
 		public const int Unathorized = 606;
-		public const int SpecifiedArrayIndexInvalid = 713;		public const int NoSuchEntryInArray = 714;
+		public const int SpecifiedArrayIndexInvalid = 713;
+		public const int NoSuchEntryInArray = 714;
 		public const int WildCardNotPermittedInSourceIp = 715;
 		public const int WildCardNotPermittedInExternalPort = 716;
 		public const int ConflictInMappingEntry = 718;

--- a/Open.Nat/Upnp/UpnpNatDevice.cs
+++ b/Open.Nat/Upnp/UpnpNatDevice.cs
@@ -367,7 +367,9 @@ namespace Open.Nat
 					 // DD-WRT Linux base router (and others probably) fails with 402-InvalidArgument when index is out of range
 					 || e.ErrorCode == UpnpConstants.InvalidArguments
 					 // LINKSYS WRT1900AC AC1900 it returns errocode 501-PAL_UPNP_SOAP_E_ACTION_FAILED
-					 || e.ErrorCode == UpnpConstants.ActionFailed)
+					 || e.ErrorCode == UpnpConstants.ActionFailed
+					 // LINKSYS EA8300 fails with 601:"Argument Value Out of Range" when index is out of range
+					 || e.ErrorCode == UpnpConstants.ArgumentValueOutOfRange)
 					{
 						NatDiscoverer.TraceSource.LogWarn("Router failed with {0}-{1}. No more mappings is assumed.", e.ErrorCode, e.ErrorText);
 						break; 
@@ -458,7 +460,9 @@ namespace Open.Nat
 					// DD-WRT Linux base router (and others probably) fails with 402-InvalidArgument when index is out of range
 				 || e.ErrorCode == UpnpConstants.InvalidArguments
 					// LINKSYS WRT1900AC AC1900 it returns errocode 501-PAL_UPNP_SOAP_E_ACTION_FAILED
-				 || e.ErrorCode == UpnpConstants.ActionFailed)
+				 || e.ErrorCode == UpnpConstants.ActionFailed
+				 // LINKSYS EA8300 fails with 601:"Argument Value Out of Range" when index is out of range
+				 || e.ErrorCode == UpnpConstants.ArgumentValueOutOfRange)
 				{
 					NatDiscoverer.TraceSource.LogWarn("Router failed with {0}-{1}. No more mappings is assumed.", e.ErrorCode, e.ErrorText);
 					return null;


### PR DESCRIPTION
When reaching the end existing mappings, LINKSYS EA8300 throws error code 601: "Argument Value Out of Range"